### PR TITLE
Added proof of concept TLS support (#7)

### DIFF
--- a/gokrazy.go
+++ b/gokrazy.go
@@ -8,6 +8,7 @@
 package gokrazy
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -28,6 +29,8 @@ var (
 	buildTimestamp = "uninitialized"
 	httpPassword   string
 	hostname       string
+	tlsConfig      *tls.Config
+	useTLS         bool
 )
 
 func configureLoopback() error {
@@ -61,6 +64,27 @@ func watchdog() {
 			log.Printf("hardware watchdog ping failed: %v", errno)
 		}
 		time.Sleep(1 * time.Second)
+	}
+}
+
+func setupTLS() error {
+	if _, err := os.Stat("/etc/ssl/gokrazy-web.pem"); !os.IsNotExist(err) {
+		cert, err := tls.LoadX509KeyPair("/etc/ssl/gokrazy-web.pem", "/etc/ssl/gokrazy-web.key.pem")
+		if err != nil {
+			return fmt.Errorf("failed loading certificate: %v", err)
+		}
+		useTLS = true
+		// See https://cipherlist.eu/
+		tlsConfig = &tls.Config{
+			Certificates:             []tls.Certificate{cert},
+			MinVersion:               tls.VersionTLS12,
+			CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
+			PreferServerCipherSuites: true,
+			CipherSuites: []uint16{
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			},
+		}
 	}
 }
 
@@ -117,7 +141,22 @@ func Boot(userBuildTimestamp string) error {
 	}
 
 	initRemoteSyslog()
+    if err := setupTLS(); err != nil {
+    	return err
+	}
 
+	return nil
+}
+
+func updateListenerPairs(httpPort, httpsPort string, useTLS bool, tlsConfig *tls.Config) error {
+	if err := updateListeners(httpPort, useTLS, nil); err != nil {
+		return err
+	}
+	if useTLS {
+		if err := updateListeners(httpsPort, useTLS, tlsConfig); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -168,7 +207,7 @@ func Supervise(commands []*exec.Cmd) error {
 		return err
 	}
 
-	if err := updateListeners("80"); err != nil {
+	if err := updateListenerPairs("80", "443", useTLS, tlsConfig); err != nil {
 		return fmt.Errorf("updating listeners: %v", err)
 	}
 
@@ -186,7 +225,7 @@ func Supervise(commands []*exec.Cmd) error {
 						m.Header.Type != syscall.RTM_DELADDR {
 						continue
 					}
-					if err := updateListeners("80"); err != nil {
+					if err := updateListenerPairs("80", "443", useTLS, tlsConfig); err != nil {
 						log.Printf("updating listeners: %v", err)
 					}
 				}
@@ -201,7 +240,7 @@ func Supervise(commands []*exec.Cmd) error {
 		signal.Notify(c, unix.SIGHUP)
 
 		for range c {
-			if err := updateListeners("80"); err != nil {
+			if err := updateListenerPairs("80", "443", useTLS, tlsConfig); err != nil {
 				log.Printf("updating listeners: %v", err)
 			}
 		}
@@ -217,7 +256,7 @@ func Supervise(commands []*exec.Cmd) error {
 
 			if err := tryStartShell(); err != nil {
 				log.Printf("could not start shell: %v", err)
-				if err := updateListeners("80"); err != nil {
+				if err := updateListenerPairs("80", "443", useTLS, tlsConfig); err != nil {
 					log.Printf("updating listeners: %v", err)
 				}
 			}

--- a/httpsredirect.go
+++ b/httpsredirect.go
@@ -1,0 +1,9 @@
+package gokrazy
+
+import "net/http"
+
+// TODO: Configurable https-port
+func httpsRedirect(w http.ResponseWriter, r *http.Request) {
+	newURI := "https://" + r.Host + r.URL.String()
+	http.Redirect(w, r, newURI, http.StatusFound)
+}

--- a/httpsredirect.go
+++ b/httpsredirect.go
@@ -4,6 +4,7 @@ import "net/http"
 
 // TODO: Configurable https-port
 func httpsRedirect(w http.ResponseWriter, r *http.Request) {
-	newURI := "https://" + r.Host + r.URL.String()
-	http.Redirect(w, r, newURI, http.StatusFound)
+	r.URL.Host = r.Host
+	r.URL.Scheme = "https"
+	http.Redirect(w, r, r.URL.String(), http.StatusFound) // Redirect to https
 }

--- a/listeners.go
+++ b/listeners.go
@@ -140,15 +140,11 @@ var (
 	listenersMu sync.Mutex
 )
 
-// tlsEnabled: Indicate, if public or private addresses should be used
 // tlsConfig: tlsConfig. nil, if the listeners should not use https (e.g. for redirects)
 func updateListeners(port string, tlsEnabled bool, tlsConfig *tls.Config) error {
 	hosts, err := PrivateInterfaceAddrs()
 	if err != nil {
 		return err
-	}
-	if tlsEnabled {
-		hosts = []string{"::"}
 	}
 
 	listenersMu.Lock()
@@ -175,8 +171,7 @@ func updateListeners(port string, tlsEnabled bool, tlsConfig *tls.Config) error 
 		addr := net.JoinHostPort(host, port)
 		ln, err := net.Listen("tcp", addr)
 		if err != nil {
-			log.Println(err) // err includes enough context
-			log.Println("(error on listen)")
+			log.Printf("listen: %v", err)
 			continue
 		}
 		log.Printf("now listening on %s", addr)


### PR DESCRIPTION
If there is a certificate and key in `/etc/ssl/gokrazy-web.{pem,key.pem}`, the web
interface listens and redirects to https.

This patch comes along with other patches in the [internal](https://github.com/gokrazy/internal/pull/4) and [tools](https://github.com/gokrazy/tools/pull/14) repositories.