### PR TITLE
Show current messages before module info

### DIFF
--- a/assets/status.tmpl
+++ b/assets/status.tmpl
@@ -25,9 +25,6 @@
 </tr>
 </table>
 
-  <h3>module info</h3>
-  <pre>{{ .Service.ModuleInfo }}</pre>
-
   <h3>stdout</h3>
   <pre>
   {{ range $idx, $line := .Service.Stdout.Lines -}}
@@ -41,6 +38,10 @@
     {{ $line }}
   {{ end }}
   </pre>
+
+  <h3>module info</h3>
+  <pre>{{ .Service.ModuleInfo }}</pre>
+
 </div>
 </div>
 


### PR DESCRIPTION
The rationale here is that I'd typically like to know how the service is doing rather than the more static compile tie configuration. Hence important/current data on top.