### PR TITLE
Quote and separate commands in log

### DIFF
--- a/supervise.go
+++ b/supervise.go
@@ -297,7 +297,7 @@ func supervise(s *service) {
 			continue
 		}
 
-		l.Printf("gokrazy: attempt %d, starting %+v", attempt, s.cmd.Args)
+		l.Printf("gokrazy: attempt %d, starting %q", attempt, s.cmd.Args)
 		s.setStarted(time.Now())
 		cmd := &exec.Cmd{
 			Path:   s.cmd.Path,


### PR DESCRIPTION
I had trouble understanding why the command (with args) I wanted to execute on gokrazy failed, because i could not see the diffrence between ['/user/echo', 'test 123'] and ['/user/echo', 'test', '123']

Output (for both examples) before:

```
  2021/09/15 13:34:00 gokrazy: attempt 1, starting [/user/echo test 123]
```

Output now:

```
  2021/09/15 13:34:00 gokrazy: attempt 1, starting ["/user/echo" "test" "123"]
```