### PR TITLE
dhcp: allow builds on non-64-bit architectures

### DIFF
--- a/cmd/dhcp/dhcp.go
+++ b/cmd/dhcp/dhcp.go
@@ -1,10 +1,3 @@
-// Only build for (linux AND (amd64 OR arm64)) due to using
-// linux-specific syscalls with uint64 for “unsigned long”:
-
-//go:build linux && (amd64 || arm64)
-// +build linux
-// +build amd64 arm64
-
 // dhcp is a minimal DHCP client for gokrazy.
 package main
 

--- a/internal/iface/iface.go
+++ b/internal/iface/iface.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package iface
 
 import (
@@ -8,9 +11,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// as per http://lxr.free-electrons.com/source/include/uapi/linux/route.h#L30
+// as per https://github.com/torvalds/linux/blob/7ddb58cb0ecae8e8b6181d736a87667cc9ab8389/include/uapi/linux/route.h#L31-L48
 type rtentry struct {
-	pad1    uint64
+	pad1    uint
 	dst     syscall.RawSockaddrInet4
 	gateway syscall.RawSockaddrInet4
 	genmask syscall.RawSockaddrInet4


### PR DESCRIPTION
Move build constraint to internal/iface which clearly shows the Linux dependency