### PR TITLE
status: live tail logs

### DIFF
--- a/internal/assets/status.tmpl
+++ b/internal/assets/status.tmpl
@@ -32,18 +32,10 @@
 {{ end }}
 
   <h3>stdout</h3>
-  <pre>
-  {{ range $idx, $line := .Service.Stdout.Lines -}}
-    {{ $line }}
-  {{ end }}
-  </pre>
+  <pre id="stdout"></pre>
 
   <h3>stderr</h3>
-  <pre>
-  {{ range $idx, $line := .Service.Stderr.Lines -}}
-    {{ $line }}
-  {{ end }}
-  </pre>
+  <pre id="stderr"></pre>
 
   <h3>module info</h3>
   <pre>{{ .Service.ModuleInfo }}</pre>
@@ -52,3 +44,18 @@
 </div>
 
 {{ template "footer.tmpl" . }}
+
+<script>
+	const maxLines = 101;
+	new EventSource("/log?path={{ .Service.Name }}&stream=stderr", { withCredentials: true }).onmessage = function(e) {
+		// Append line to whatever is in the `pre` block. Then, truncate number of lines to `maxLines`.
+		// This is extremely inefficient, since we're splitting into component lines and joining them
+		// back each time a line is added.
+		var txt = document.getElementById("stderr").innerText + e.data + "\n";
+		document.getElementById("stderr").innerText = txt.split('\n').slice(-maxLines).join('\n')
+	};
+	new EventSource("/log?path={{ .Service.Name }}&stream=stdout", { withCredentials: true }).onmessage = function(e) {
+		var txt = document.getElementById("stdout").innerText + e.data + "\n";
+		document.getElementById("stdout").innerText = txt.split('\n').slice(-maxLines).join('\n')
+	};
+</script>


### PR DESCRIPTION
Create a `/log` endpoint for streaming stdout/stderr logs for processes.
Replace status page stdout/stderr to call into /log to stream logs and
live update page.