### PR TITLE
docs(readme): add description about accessing permanent data

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ currently active file system) when updating.
 If you’d like to store permanent data (i.e. data which will not be
 overwritten on the next update), you’ll need to create an ext4 file
 system on the last partition. If your SD card is `/dev/sdx`, use
-`mkfs.ext4 /dev/sdx4`.
+`mkfs.ext4 /dev/sdx4`. After you successfully created the new filesystem
+on the forth partition, gokrazy will automatically mount the filesystem
+under `/perm` during startup. Use this mount directory to store your permanent data.
 
 # Customization
 


### PR DESCRIPTION
Hey,

I added short information about how to access the permanent data on the forth partition. I could not find any documentation about this in the readme or on the website. 

I would also like to add a simple user guide for the website. How do you create the pages? I see its based on `grav`. Is there a quick start guide about how to add a new site?

Felix :) 