### PR TITLE
supervise: wait for services to stop before reboot

### DIFF
--- a/proc.go
+++ b/proc.go
@@ -1,0 +1,48 @@
+package gokrazy
+
+import "sync"
+
+type statusCode int32
+
+const (
+	Stopped  statusCode = iota // Process not running
+	Running                    // Process was started and is very likely still running
+	Stopping                   // Process is being stopped, but it might still be running
+)
+
+type processState struct {
+	lock         sync.Mutex
+	statusChange *sync.Cond
+	status       statusCode
+}
+
+func NewProcessState() *processState {
+	p := &processState{}
+	p.statusChange = sync.NewCond(&p.lock)
+
+	return p
+}
+
+func (p *processState) Set(status statusCode) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.status == Stopped && status == Stopping {
+		// Not a valid state transition. Ignore it.
+		return
+	}
+
+	p.status = status
+	p.statusChange.Broadcast()
+}
+
+func (p *processState) WaitTill(status statusCode) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	for p.status != status {
+		p.statusChange.Wait()
+	}
+
+	return
+}


### PR DESCRIPTION
Currently, rebooting/upgrading the instance sends a TERM signal to all
running services, waits 1 second and then reboots. Processes that take
longer to cleanly stop can't do so.

Instead, give each service up to 15s to do a clean shutdown. Reboot 15s
after the command is sent, or after all services are stopped, whichever
comes first.

To make it easier to kill entire process tree for a service, create a
per-service process group. Stopping the service can be done by sending a
single signal to the process group.