### PR TITLE
website: update Tailscale VPN documentation

### DIFF
--- a/website/content/userguide/install/tailscale.md
+++ b/website/content/userguide/install/tailscale.md
@@ -53,7 +53,12 @@ EOF
 
 **Option B: unattended authentication with auth key**
 
-Navigate to [Tailscale console] and open Settings / Keys. Generate auth key.
+Alternatively,
+navigate to [Tailscale console] and open Settings / Keys. Generate auth key.
+
+Include the key to tailscale flags:
+
+[Tailscale console]: https://login.tailscale.com/ "Tailscale management console login.tailscale.com"
 
 ```shell
 cat > flags/tailscale.com/cmd/tailscale/flags.txt <<EOF
@@ -77,7 +82,7 @@ gokr-packer \
   tailscale.com/cmd/tailscale
 ```
 
-We include `mkfs` to automatically initialize filesystem on the `/perm`
+We include `mkfs` to automatically initialize a filesystem on the `/perm`
 partition on first boot.
 
 ## Step 3. authenticate (interactive only)

--- a/website/content/userguide/install/tailscale.md
+++ b/website/content/userguide/install/tailscale.md
@@ -85,8 +85,7 @@ Navigate to [Tailscale console] and open Settings / Keys. Generate auth key.
 ```shell
 cat > flags/tailscale.com/cmd/tailscale/flags.txt <<EOF
 up
---auth-key
-tskey-AAAAAAAAAAAA-AAAAAAAAAAAAAAAAAAAAAA
+--auth-key=tskey-AAAAAAAAAAAA-AAAAAAAAAAAAAAAAAAAAAA
 EOF
 ```
 


### PR DESCRIPTION
Replace use of breakglass with instructions to use interactive login.
This depends on tailscale/tailscale#4117 being merged.

Add mkfs into the example so that /perm filesystem is initialized.

Add instructions how to use auth-key for unattended device auth instead
of having to use browser interactively.

Append to tailscaled/flags.txt instead of overwriting.

Clarify and update the tsnet example. Add mention of TS_AUTHKEY
as alternative here too.