### PR TITLE
Improve authenticated

### DIFF
--- a/authenticated.go
+++ b/authenticated.go
@@ -22,6 +22,7 @@ func authenticated(w http.ResponseWriter, r *http.Request) {
 
 	b, err := base64.StdEncoding.DecodeString(s[1])
 	if err != nil {
+		w.Header().Set("WWW-Authenticate", `Basic realm="gokrazy"`)
 		http.Error(w, fmt.Sprintf("could not decode Authorization header as base64: %v", err), http.StatusUnauthorized)
 		return
 	}
@@ -30,6 +31,7 @@ func authenticated(w http.ResponseWriter, r *http.Request) {
 	if len(pair) != 2 ||
 		pair[0] != "gokrazy" ||
 		pair[1] != httpPassword {
+		w.Header().Set("WWW-Authenticate", `Basic realm="gokrazy"`)
 		http.Error(w, "invalid username/password", http.StatusUnauthorized)
 		return
 	}

--- a/authenticated.go
+++ b/authenticated.go
@@ -1,6 +1,7 @@
 package gokrazy
 
 import (
+	"crypto/subtle"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -30,7 +31,7 @@ func authenticated(w http.ResponseWriter, r *http.Request) {
 	username, password, found := strings.Cut(string(b), ":")
 	if !found ||
 		username != "gokrazy" ||
-		password != httpPassword {
+		subtle.ConstantTimeCompare([]byte(password), []byte(httpPassword)) != 1 {
 		w.Header().Set("WWW-Authenticate", `Basic realm="gokrazy"`)
 		http.Error(w, "invalid username/password", http.StatusUnauthorized)
 		return

--- a/authenticated.go
+++ b/authenticated.go
@@ -13,24 +13,24 @@ func authenticated(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "httpPassword not set", http.StatusInternalServerError)
 		return
 	}
-	s := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
-	if len(s) != 2 || s[0] != "Basic" {
+	kind, encoded, found := strings.Cut(r.Header.Get("Authorization"), " ")
+	if !found || kind != "Basic" {
 		w.Header().Set("WWW-Authenticate", `Basic realm="gokrazy"`)
 		http.Error(w, "no Basic Authorization header set", http.StatusUnauthorized)
 		return
 	}
 
-	b, err := base64.StdEncoding.DecodeString(s[1])
+	b, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		w.Header().Set("WWW-Authenticate", `Basic realm="gokrazy"`)
 		http.Error(w, fmt.Sprintf("could not decode Authorization header as base64: %v", err), http.StatusUnauthorized)
 		return
 	}
 
-	pair := strings.SplitN(string(b), ":", 2)
-	if len(pair) != 2 ||
-		pair[0] != "gokrazy" ||
-		pair[1] != httpPassword {
+	username, password, found := strings.Cut(string(b), ":")
+	if !found ||
+		username != "gokrazy" ||
+		password != httpPassword {
 		w.Header().Set("WWW-Authenticate", `Basic realm="gokrazy"`)
 		http.Error(w, "invalid username/password", http.StatusUnauthorized)
 		return


### PR DESCRIPTION
_I want to contribute to this project and I thought that I could get started with a minor PR. Feel free to tell me what I could do better_

I took a look at `authenticated.go` and found 3 minors improvements that could be made:
1. always send the `WWW-Authenticate` on authentication failure. Without this, firefox is stuck on the 401 page and does not prompt the user for a new password (it sends the same password every time). With this change it instead asks the user for a new password every time. If the user clicks "cancel", then the error message is displayed.
2. use the newly added [`strings.Cut`](https://pkg.go.dev/strings#Cut) (since go.mod already indicates `go 1.18` I guess this is ok)
3. compare the password in constant time (to mitigate timing attack)

Since those 3 changes are pretty small, I gathered them in one PR (but separated commits). If you prefer, I can split the commits into multiple PRs.