### PR TITLE
supervisor: stop service on exit 0

### DIFF
--- a/supervise.go
+++ b/supervise.go
@@ -473,7 +473,8 @@ func supervise(s *service) {
 			}
 			l.Println("gokrazy: " + err.Error())
 		} else {
-			l.Printf("gokrazy: exited successfully")
+			l.Printf("gokrazy: exited successfully, stopping")
+			s.setStopped(true)
 		}
 
 		if s.supervisionMode() == superviseOnce {

--- a/website/content/userguide/process-interface.md
+++ b/website/content/userguide/process-interface.md
@@ -22,8 +22,8 @@ More specifically, gokrazy:
 	* Extra command-line flags or environment variables can be specified using
       [per-package configuration](/userguide/package-config/).
 1. When your binary’s process exits, gokrazy restarts it!
-	* If the process exits with status code `125`, gokrazy will stop
-      supervision. Exiting with status code `125` when the
+	* If the process exits with status code `0` (or `125`), gokrazy will stop
+      supervision. Exiting immediately with status code `0` when the
       `GOKRAZY_FIRST_START=1` environment variable is set means “don’t start the
       program on boot”
 


### PR DESCRIPTION
fixes #125

> I think we actually can do the dont-supervise-on-exit-0 change. It’s not really a case I typically have with the programs I run on gokrazy.

> For context, the platform was built for services that run indefinitely, with exit code 125 introduced initially for breakglass which should be off-by-default.