### PR TITLE
Indicate where default password can be recovered on macOS/Darwin

### DIFF
--- a/website/content/quickstart/_index.markdown
+++ b/website/content/quickstart/_index.markdown
@@ -131,7 +131,7 @@ After booting from this SD card, your device will:
 - obtain an IP address for hostname “gokrazy” via DHCP (IPv4) and SLAAC (IPv6)
 - synchronize the clock using NTP
 - expose a password-authenticated web interface on private IP addresses<br>
-  (the default password can be recovered from <code>~/.config/gokrazy/http-password.txt</code>)
+  (the default password can be recovered from `~/.config/gokrazy/http-password.txt` on Linux or from `~/Library/Application\ Support/gokrazy/http-password.txt` on macOS/Darwin)
 - supervise all installed programs (only the hello world program in this example)
 
 To interact with your device, you can:


### PR DESCRIPTION
The path differs for macOS/Darwin.

Related to: https://github.com/gokrazy/internal/pull/12

Note: I had to change `<code> ... </code>` into backticks to avoid strikethrough in artifacts.

![render](https://user-images.githubusercontent.com/4902157/170690643-bf951c9a-cef3-4ca5-baa4-8e558194a5fc.png)