### PR TITLE
Add krazyotelcol to "Written for gokrazy"

### DIFF
--- a/website/content/packages/showcase.markdown
+++ b/website/content/packages/showcase.markdown
@@ -43,6 +43,14 @@ or directly from Spotify.
 appliance that provides a basic SSH to serial console bridge for accessing
 remote devices.
 
+### krazyotelcol
+[**krazyotelcol**](https://github.com/svrnm/krazyotelcol) is an appliance 
+running the [OpenTelemetry 
+Collector](https://github.com/open-telemetry/opentelemetry-collector), a 
+vendor-agnostic implementation on how to receive, process and export telemetry
+data.
+
+
 ## Successfully tested
 
 The following third-party programs have been successfully used with gokrazy


### PR DESCRIPTION
Stumbled upon gokrazy the other day watching @stapelberg's video on "Why I wrote my own rsync", I immediately wanted to give it a try with the OpenTelemetry collector. *krazyotelcol* is the result of that!

Thanks for this amazing project :-)