### PR TITLE
userguide: enable search by generating index.json as output

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -23,3 +23,5 @@ identifier = "ds"
 url = "https://github.com/gokrazy/gokrazy"
 weight = 10
 
+[outputs]
+home = [ "HTML", "RSS", "JSON"]


### PR DESCRIPTION
This should enable the search in the GoKrazy userguide and solves https://github.com/gokrazy/gokrazy/issues/145.

See https://learn.netlify.app/en/basics/configuration/#activate-search for further information.

I guess that you're going to re-generate the documentation as you did with in the past - which then should generate the `index.json`.