### PR TITLE
implement Poweroff (and refactor around killSupervisedServices)

### DIFF
--- a/cmd/ntp/privdrop.go
+++ b/cmd/ntp/privdrop.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"os/signal"
 	"syscall"
 	"unsafe"
 )
@@ -83,19 +82,5 @@ func mustDropPrivileges(rtc *os.File) {
 		},
 		AmbientCaps: []uintptr{CAP_SYS_TIME},
 	}
-
-	if err := cmd.Start(); err != nil {
-		log.Fatal(err)
-	}
-	go func() {
-		// forward signals to the child process to ensure proper termination on SIGTERM
-		// see https://github.com/gokrazy/gokrazy/pull/177
-		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, syscall.SIGTERM)
-		for s := range ch {
-			cmd.Process.Signal(s)
-		}
-	}()
-
-	log.Fatal(cmd.Wait())
+	log.Fatal(cmd.Run())
 }

--- a/proc.go
+++ b/proc.go
@@ -23,6 +23,12 @@ func NewProcessState() *processState {
 	return p
 }
 
+func (p *processState) Get() statusCode {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	return p.status
+}
+
 func (p *processState) Set(status statusCode) {
 	p.lock.Lock()
 	defer p.lock.Unlock()

--- a/proc.go
+++ b/proc.go
@@ -49,6 +49,4 @@ func (p *processState) WaitTill(status statusCode) {
 	for p.status != status {
 		p.statusChange.Wait()
 	}
-
-	return
 }

--- a/supervise.go
+++ b/supervise.go
@@ -546,6 +546,9 @@ func signalSupervisedServices(signal syscall.Signal) []*processState {
 
 	states := make([]*processState, 0, len(services.S))
 	for _, s := range services.S {
+		// s.Stopped() only checks the "stopped" flag of the service (if it shouldn't restart).
+		// We check the actual state as well to be sure to re-send a signal if we are already
+		// in the "Stopping" state.
 		if s.Stopped() && s.state.Get() == Stopped {
 			continue
 		}

--- a/supervise.go
+++ b/supervise.go
@@ -260,10 +260,6 @@ func (s *service) setStopped(val bool) {
 	s.stopped = val
 }
 
-func (s *service) waitTillStopped() {
-	s.state.WaitTill(Stopped)
-}
-
 func (s *service) Started() time.Time {
 	s.startedMu.RLock()
 	defer s.startedMu.RUnlock()

--- a/supervise.go
+++ b/supervise.go
@@ -282,9 +282,13 @@ func (s *service) Signal(signal syscall.Signal) error {
 	s.processMu.RLock()
 	defer s.processMu.RUnlock()
 	if s.process != nil {
-		err := s.process.Signal(signal)
-		if err != nil && !errors.Is(err, os.ErrProcessDone) { // ignore "process not found"
-			return err
+		// Use syscall.Kill instead of s.process.Signal since we want
+		// to the send the signal to all process of the group (-pid)
+		err := syscall.Kill(-s.process.Pid, signal)
+		if errno, ok := err.(syscall.Errno); ok {
+			if errno == syscall.ESRCH {
+				return nil // no such process, nothing to signal
+			}
 		}
 		return err
 	}

--- a/supervise.go
+++ b/supervise.go
@@ -563,6 +563,7 @@ func signalSupervisedServices(signal syscall.Signal) []*processState {
 // killSupervisedServices is called before rebooting when upgrading, allowing
 // processes to terminate in an orderly fashion.
 func killSupervisedServices(signalDelay time.Duration) {
+	log.Println("sending sigterm to all services")
 	termStates := signalSupervisedServices(syscall.SIGTERM)
 	termDone := make(chan struct{})
 	go func() {
@@ -574,11 +575,11 @@ func killSupervisedServices(signalDelay time.Duration) {
 
 	select {
 	case <-termDone:
-		log.Println("All processes shut down")
+		log.Println("all services shut down")
 		return
 	case <-time.After(signalDelay):
 	}
-	log.Println("Some processes did not stop, send sigkill")
+	log.Println("some services did not stop, send sigkill")
 
 	killStates := signalSupervisedServices(syscall.SIGKILL)
 	killDone := make(chan struct{})
@@ -591,12 +592,12 @@ func killSupervisedServices(signalDelay time.Duration) {
 
 	select {
 	case <-killDone:
-		log.Println("All processes shut down")
+		log.Println("all services shut down")
 		return
 	case <-time.After(signalDelay):
 	}
 
-	log.Println("Some processes did not stop after sigkill")
+	log.Println("some services did not stop after sigkill")
 }
 
 func findSvc(path string) *service {

--- a/update.go
+++ b/update.go
@@ -369,19 +369,8 @@ func initUpdate() error {
 	return nil
 }
 
-func killSupervisedServicesAndUmountPerm(maxDelay time.Duration) {
-	doneCh := make(chan struct{})
-	go func() {
-		killSupervisedServices()
-		close(doneCh)
-	}()
-
-	select {
-	case <-doneCh:
-		log.Println("All processes shut down")
-	case <-time.After(maxDelay):
-		log.Println("Timed out waiting for processes to shut down")
-	}
+func killSupervisedServicesAndUmountPerm(signalDelay time.Duration) {
+	killSupervisedServices(signalDelay)
 
 	log.Println("Unmounting /perm")
 	if err := syscall.Unmount("/perm", unix.MNT_FORCE); err != nil {

--- a/update.go
+++ b/update.go
@@ -331,9 +331,19 @@ func initUpdate() error {
 			return
 		}
 
+		signalDelay := time.Minute
+		if s := r.FormValue("wait_per_signal"); s != "" {
+			var err error
+			signalDelay, err = time.ParseDuration(s)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+
 		rc := http.NewResponseController(w)
 		start := time.Now()
-		killSupervisedServicesAndUmountPerm(15 * time.Second)
+		killSupervisedServicesAndUmountPerm(signalDelay)
 		fmt.Fprintf(w, "All services killed in %s\n", time.Since(start))
 		rc.Flush()
 
@@ -350,9 +360,19 @@ func initUpdate() error {
 			return
 		}
 
+		signalDelay := time.Minute
+		if s := r.FormValue("wait_per_signal"); s != "" {
+			var err error
+			signalDelay, err = time.ParseDuration(s)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+
 		rc := http.NewResponseController(w)
 		start := time.Now()
-		killSupervisedServicesAndUmountPerm(15 * time.Second)
+		killSupervisedServicesAndUmountPerm(signalDelay)
 		fmt.Fprintf(w, "All services killed in %s\n", time.Since(start))
 		rc.Flush()
 

--- a/update.go
+++ b/update.go
@@ -352,6 +352,7 @@ func initUpdate() error {
 		rc.Flush()
 
 		go func() {
+			time.Sleep(time.Second) // give the http response some time to be sent
 			if err := reboot(); err != nil {
 				log.Println("could not reboot:", err)
 			}
@@ -384,6 +385,7 @@ func initUpdate() error {
 		rc.Flush()
 
 		go func() {
+			time.Sleep(time.Second) // give the http response some time to be sent
 			if err := unix.Reboot(unix.LINUX_REBOOT_CMD_POWER_OFF); err != nil {
 				log.Println("could not power off:", err)
 			}

--- a/update.go
+++ b/update.go
@@ -348,11 +348,14 @@ func initUpdate() error {
 		rc.Flush()
 
 		log.Println("Rebooting")
-		if err := reboot(); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
 		w.Write([]byte("Rebooting...\n"))
 		rc.Flush()
+
+		go func() {
+			if err := reboot(); err != nil {
+				log.Println("could not reboot:", err)
+			}
+		}()
 	})
 	http.HandleFunc("/poweroff", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -377,11 +380,14 @@ func initUpdate() error {
 		rc.Flush()
 
 		log.Println("Powering off")
-		if err := unix.Reboot(unix.LINUX_REBOOT_CMD_POWER_OFF); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
 		w.Write([]byte("Powering off...\n"))
 		rc.Flush()
+
+		go func() {
+			if err := unix.Reboot(unix.LINUX_REBOOT_CMD_POWER_OFF); err != nil {
+				log.Println("could not power off:", err)
+			}
+		}()
 	})
 	http.HandleFunc("/uploadtemp/", uploadTemp)
 	http.HandleFunc("/divert", divert)


### PR DESCRIPTION
Fixes #176 

I took the liberty of refacoring `killSupervisedServices` on the way:
- it sends SIGTERM to all running processes
- waits up to 15 seconds (`=signalDelay`)
- sends SIGKILL to the remaining processes
- waits up to 15 seconds (`=signalDelay`)
- returns

So that we get a higher chance of all processes having been terminated before unmount `/perm`.

(I initially replaced `syscall.Kill` with `process.Signal` and proper error checking, however rebooting always took 30s. After I while, I figured that `process.Signal` does not send the signal to the group! I reverted my changes and updated the comment :)

I have no idea how to hook this to the power button: I will let you take it from here