### PR TITLE
dashboard: link to the raw log

### DIFF
--- a/internal/assets/status.tmpl
+++ b/internal/assets/status.tmpl
@@ -43,10 +43,10 @@
     </p>
     {{ end }}
 
-    <h3>stdout</h3>
+    <h3>stdout <small class="pull-right">Log lines: <input type="number" value="101" size="4" id="stdout_len"></small></h3>
     <pre id="stdout"></pre>
 
-    <h3>stderr</h3>
+    <h3>stderr <small class="pull-right">Log lines: <input type="number" value="101" size="4" id="stderr_len"></small></h3>
     <pre id="stderr"></pre>
 
     <h3>module info</h3>
@@ -58,16 +58,38 @@
 {{ template "footer.tmpl" . }}
 
 <script>
-    const maxLines = 101;
+    // truncateAt finds the position at which the prefix should be removed
+    // to have the right number of lines (for use with slice).
+    function truncateAt(s, maxLines) {
+      let found = 0;
+      let i = s.length + 1;
+      while (true) {
+        i = s.lastIndexOf("\n", i - 1);
+        if (i == -1) {
+          return 0;
+        }
+        found++;
+        if (found >= maxLines) {
+          return i + 1;
+        }
+      }
+    }
+
+    const stderrElt = document.getElementById("stderr");
+    const stderrEltLen = document.getElementById("stderr_len");
+
+    const stdoutElt = document.getElementById("stdout");
+    const stdoutEltLen = document.getElementById("stdout_len");
+
     new EventSource("/log?path={{ .Service.Name }}&stream=stderr", { withCredentials: true }).onmessage = function(e) {
-        // Append line to whatever is in the `pre` block. Then, truncate number of lines to `maxLines`.
-        // This is extremely inefficient, since we're splitting into component lines and joining them
-        // back each time a line is added.
-        var txt = document.getElementById("stderr").innerText + e.data + "\n";
-        document.getElementById("stderr").innerText = txt.split('\n').slice(-maxLines).join('\n')
+      // Append line to whatever is in the `pre` block. Then, truncate number of lines to `maxLines`.
+      const txt = stderrElt.innerText + e.data + "\n";
+      const i = truncateAt(stderrElt.innerText, +stderrEltLen.value);
+      stderrElt.innerText = txt.slice(i);
     };
     new EventSource("/log?path={{ .Service.Name }}&stream=stdout", { withCredentials: true }).onmessage = function(e) {
-        var txt = document.getElementById("stdout").innerText + e.data + "\n";
-        document.getElementById("stdout").innerText = txt.split('\n').slice(-maxLines).join('\n')
+      const txt = stdoutElt.innerText + e.data + "\n";
+      const i = truncateAt(stdoutElt.innerText, +stdoutEltLen.value);
+      stdoutElt.innerText = txt.slice(i);
     };
 </script>

--- a/internal/assets/status.tmpl
+++ b/internal/assets/status.tmpl
@@ -43,10 +43,10 @@
     </p>
     {{ end }}
 
-    <h3>stdout <small class="pull-right">Log lines: <input type="number" value="101" size="4" id="stdout_len"></small></h3>
+    <h3>stdout <small><a href="/log?path={{ .Service.Name }}&stream=stdout">raw log</a></small></h3>
     <pre id="stdout"></pre>
 
-    <h3>stderr <small class="pull-right">Log lines: <input type="number" value="101" size="4" id="stderr_len"></small></h3>
+    <h3>stderr <small><a href="/log?path={{ .Service.Name }}&stream=stderr">raw log</a></small></h3>
     <pre id="stderr"></pre>
 
     <h3>module info</h3>
@@ -76,20 +76,19 @@
     }
 
     const stderrElt = document.getElementById("stderr");
-    const stderrEltLen = document.getElementById("stderr_len");
-
     const stdoutElt = document.getElementById("stdout");
-    const stdoutEltLen = document.getElementById("stdout_len");
+
+    const maxLines = 101;
 
     new EventSource("/log?path={{ .Service.Name }}&stream=stderr", { withCredentials: true }).onmessage = function(e) {
       // Append line to whatever is in the `pre` block. Then, truncate number of lines to `maxLines`.
       const txt = stderrElt.innerText + e.data + "\n";
-      const i = truncateAt(stderrElt.innerText, +stderrEltLen.value);
+      const i = truncateAt(stderrElt.innerText, maxLines);
       stderrElt.innerText = txt.slice(i);
     };
     new EventSource("/log?path={{ .Service.Name }}&stream=stdout", { withCredentials: true }).onmessage = function(e) {
       const txt = stdoutElt.innerText + e.data + "\n";
-      const i = truncateAt(stdoutElt.innerText, +stdoutEltLen.value);
+      const i = truncateAt(stdoutElt.innerText, maxLines);
       stdoutElt.innerText = txt.slice(i);
     };
 </script>


### PR DESCRIPTION
Currently the number of lines in the dashboard is hard-coded at 101.
This is sometimes not enough (I want to debug victoria metrics: a panic yields the stacktrace for tens of gorountines, which don't fit in 101 lines).

This PR introduces an `input` at the right of the log name, to adjust the number of log lines. This is set to 101 by default and gets considered everytime a new log line is produced. I tried to add some JS optimization along the way.

![2023-03-06-143158](https://user-images.githubusercontent.com/3864879/223124910-e2927aec-725b-47e7-bc1d-51cc6c7d1c47.png)

What do you think?