### PR TITLE
dashboard: refactor log line truncation logic

### DIFF
--- a/internal/assets/status.tmpl
+++ b/internal/assets/status.tmpl
@@ -57,7 +57,8 @@
 
 {{ template "footer.tmpl" . }}
 
-<script>const maxLines = 101;
+<script>
+    const maxLines = 101;
     function newLogrotate(elt) {
       var lines = 0;
       return function (e) {

--- a/internal/assets/status.tmpl
+++ b/internal/assets/status.tmpl
@@ -58,8 +58,8 @@
 {{ template "footer.tmpl" . }}
 
 <script>
-    const maxLines = 101;
     function newLogrotate(elt) {
+      const maxLines = 101;
       var lines = 0;
       return function (e) {
         const line = e.data;

--- a/internal/assets/status.tmpl
+++ b/internal/assets/status.tmpl
@@ -58,37 +58,45 @@
 {{ template "footer.tmpl" . }}
 
 <script>
-    // truncateAt finds the position at which the prefix should be removed
-    // to have the right number of lines (for use with slice).
-    function truncateAt(s, maxLines) {
-      let found = 0;
-      let i = s.length + 1;
-      while (true) {
-        i = s.lastIndexOf("\n", i - 1);
-        if (i == -1) {
-          return 0;
-        }
-        found++;
-        if (found >= maxLines) {
-          return i + 1;
-        }
-      }
-    }
-
-    const stderrElt = document.getElementById("stderr");
-    const stdoutElt = document.getElementById("stdout");
-
     const maxLines = 101;
 
-    new EventSource("/log?path={{ .Service.Name }}&stream=stderr", { withCredentials: true }).onmessage = function(e) {
+    const stderrElt = document.getElementById("stderr");
+    var stderrLines = 0;
+    new EventSource("/log?path={{ .Service.Name }}&stream=stderr", {
+      withCredentials: true,
+    }).onmessage = function (e) {
       // Append line to whatever is in the `pre` block. Then, truncate number of lines to `maxLines`.
-      const txt = stderrElt.innerText + e.data + "\n";
-      const i = truncateAt(stderrElt.innerText, maxLines);
+      const line = e.data;
+
+      const txt = stderrElt.innerText + line + "\n";
+      stderrLines += line.split("\n").length;
+
+      var toRemove = stderrLines - maxLines;
+      var i = 0;
+      while (toRemove-- > 0) {
+        i = txt.indexOf("\n", i) + 1;
+        stderrLines--;
+      }
       stderrElt.innerText = txt.slice(i);
     };
-    new EventSource("/log?path={{ .Service.Name }}&stream=stdout", { withCredentials: true }).onmessage = function(e) {
-      const txt = stdoutElt.innerText + e.data + "\n";
-      const i = truncateAt(stdoutElt.innerText, maxLines);
+
+    const stdoutElt = document.getElementById("stdout");
+    var stdoutLines = 0;
+    new EventSource("/log?path={{ .Service.Name }}&stream=stdout", {
+      withCredentials: true,
+    }).onmessage = function (e) {
+      // Append line to whatever is in the `pre` block. Then, truncate number of lines to `maxLines`.
+      const line = e.data;
+
+      const txt = stdoutElt.innerText + line + "\n";
+      stdoutLines += line.split("\n").length;
+
+      var toRemove = stdoutLines - maxLines;
+      var i = 0;
+      while (toRemove-- > 0) {
+        i = txt.indexOf("\n", i) + 1;
+        stdoutLines--;
+      }
       stdoutElt.innerText = txt.slice(i);
     };
 </script>

--- a/internal/assets/status.tmpl
+++ b/internal/assets/status.tmpl
@@ -57,46 +57,29 @@
 
 {{ template "footer.tmpl" . }}
 
-<script>
-    const maxLines = 101;
+<script>const maxLines = 101;
+    function newLogrotate(elt) {
+      var lines = 0;
+      return function (e) {
+        const line = e.data;
+        const txt = elt.innerText + line + "\n";
+        lines += line.split("\n").length;
 
-    const stderrElt = document.getElementById("stderr");
-    var stderrLines = 0;
+        var toRemove = lines - maxLines;
+        var i = 0;
+        while (toRemove-- > 0) {
+          i = txt.indexOf("\n", i) + 1;
+          lines--;
+        }
+        elt.innerText = txt.slice(i);
+      };
+    }
+
     new EventSource("/log?path={{ .Service.Name }}&stream=stderr", {
       withCredentials: true,
-    }).onmessage = function (e) {
-      // Append line to whatever is in the `pre` block. Then, truncate number of lines to `maxLines`.
-      const line = e.data;
+    }).onmessage = newLogrotate(document.getElementById("stderr"));
 
-      const txt = stderrElt.innerText + line + "\n";
-      stderrLines += line.split("\n").length;
-
-      var toRemove = stderrLines - maxLines;
-      var i = 0;
-      while (toRemove-- > 0) {
-        i = txt.indexOf("\n", i) + 1;
-        stderrLines--;
-      }
-      stderrElt.innerText = txt.slice(i);
-    };
-
-    const stdoutElt = document.getElementById("stdout");
-    var stdoutLines = 0;
     new EventSource("/log?path={{ .Service.Name }}&stream=stdout", {
       withCredentials: true,
-    }).onmessage = function (e) {
-      // Append line to whatever is in the `pre` block. Then, truncate number of lines to `maxLines`.
-      const line = e.data;
-
-      const txt = stdoutElt.innerText + line + "\n";
-      stdoutLines += line.split("\n").length;
-
-      var toRemove = stdoutLines - maxLines;
-      var i = 0;
-      while (toRemove-- > 0) {
-        i = txt.indexOf("\n", i) + 1;
-        stdoutLines--;
-      }
-      stdoutElt.innerText = txt.slice(i);
-    };
+    }).onmessage = newLogrotate(document.getElementById("stdout"));
 </script>

--- a/internal/assets/status.tmpl
+++ b/internal/assets/status.tmpl
@@ -58,16 +58,37 @@
 {{ template "footer.tmpl" . }}
 
 <script>
+    // truncateAt finds the position at which the prefix should be removed
+    // to have the right number of lines (for use with slice).
+    function truncateAt(s, maxLines) {
+      let found = 0;
+      let i = s.length + 1;
+      while (true) {
+        i = s.lastIndexOf("\n", i - 1);
+        if (i == -1) {
+          return 0;
+        }
+        found++;
+        if (found >= maxLines) {
+          return i + 1;
+        }
+      }
+    }
+
+    const stderrElt = document.getElementById("stderr");
+    const stdoutElt = document.getElementById("stdout");
+
     const maxLines = 101;
+
     new EventSource("/log?path={{ .Service.Name }}&stream=stderr", { withCredentials: true }).onmessage = function(e) {
-        // Append line to whatever is in the `pre` block. Then, truncate number of lines to `maxLines`.
-        // This is extremely inefficient, since we're splitting into component lines and joining them
-        // back each time a line is added.
-        var txt = document.getElementById("stderr").innerText + e.data + "\n";
-        document.getElementById("stderr").innerText = txt.split('\n').slice(-maxLines).join('\n')
+      // Append line to whatever is in the `pre` block. Then, truncate number of lines to `maxLines`.
+      const txt = stderrElt.innerText + e.data + "\n";
+      const i = truncateAt(stderrElt.innerText, maxLines);
+      stderrElt.innerText = txt.slice(i);
     };
     new EventSource("/log?path={{ .Service.Name }}&stream=stdout", { withCredentials: true }).onmessage = function(e) {
-        var txt = document.getElementById("stdout").innerText + e.data + "\n";
-        document.getElementById("stdout").innerText = txt.split('\n').slice(-maxLines).join('\n')
+      const txt = stdoutElt.innerText + e.data + "\n";
+      const i = truncateAt(stdoutElt.innerText, maxLines);
+      stdoutElt.innerText = txt.slice(i);
     };
 </script>


### PR DESCRIPTION
Following #179 

I think this is the fastest logic without introducing a new state (which would keep in memory the number of lines, to prevent having to count from 0 each time).