### PR TITLE
dashboard: show latest stdout and stderr lines

### DIFF
--- a/internal/assets/overview.tmpl
+++ b/internal/assets/overview.tmpl
@@ -23,13 +23,18 @@
 {{ end }}
 </td>
 <td class="lastlog">
-{{ last $svc.Stdout.Lines $svc.Stderr.Lines }}
+{{ if $svc.Stdout.Lines }}
+<small>stdout: </small>{{last $svc.Stdout.Lines }}<br/>
+{{ end }}
+{{ if $svc.Stderr.Lines }}
+<small>stderr: </small>{{last $svc.Stderr.Lines }}<br/>
+{{ end }}
 </td>
 </tr>
 {{ end }}
 
 </table>
-</div>  
+</div>
 <div class="col-md-12">
 <h2>memory</h2>
 {{ megabytes (index .Meminfo "MemTotal") }} total, {{ megabytes (index .Meminfo "MemAvailable") }} available<br>

--- a/status.go
+++ b/status.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -143,13 +142,11 @@ var templates = template.Must(template.New("root").
 			return time.Since(t).Seconds() < 5
 		},
 
-		"last": func(stdout, stderr []string) string {
-			if len(stdout) == 0 && len(stderr) == 0 {
+		"last": func(s []string) string {
+			if len(s) == 0 {
 				return ""
 			}
-			both := append(stdout, stderr...)
-			sort.Strings(both)
-			return both[len(both)-1]
+			return s[len(s)-1]
 		},
 
 		"megabytes": func(val int64) string {


### PR DESCRIPTION
The current logic showing the "last log line" on the dashboard is flawed if sorting the log lines does not result in a chronological order.

Example with an empty stdout and the following stderr:
```
Hello world
A beautiful day
```

The current code sorts the lines and takes the last element. In my example, it returns `Hello world`, which is unexpected.

https://github.com/gokrazy/gokrazy/blob/ac1c5aaf638d8de41aca7c234c1c09ab61b040df/status.go#L146-L153

I have tried to fix the logic, but choosing between stderr and stdout will be lottery (as long as the timestamp is not properly recorded).

Hence I resorted to showing both, when present:
![2023-03-12-215629](https://user-images.githubusercontent.com/3864879/224573185-54e91143-f002-4fdd-9f41-be7a496d00e9.png)

I find the result quite good, since most services are only using stderr (and when both are present, no that much space is wasted).

What do you think?
