### PR TITLE
dhcp: wait indefinitely for interface to appear

### DIFF
--- a/cmd/dhcp/dhcp.go
+++ b/cmd/dhcp/dhcp.go
@@ -277,6 +277,18 @@ func deprioritizeRoutesWhenDown(nl *netlink.Handle, ifname string, extraRoutePri
 	}
 }
 
+func waitForInterface(ifname string) {
+	t := time.NewTicker(1 * time.Second)
+	defer t.Stop()
+
+	log.Printf("waiting indefinitely for %s to appear", ifname)
+	for range t.C {
+		if _, err := net.InterfaceByName(ifname); err == nil {
+			return
+		}
+	}
+}
+
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	var (
@@ -305,6 +317,8 @@ func main() {
 		log.Fatal(err)
 	}
 	hostname := string(utsname.Nodename[:bytes.IndexByte(utsname.Nodename[:], 0)])
+
+	waitForInterface(*ifname)
 
 	nl, err := netlink.NewHandle(netlink.FAMILY_V4)
 	if err != nil {


### PR DESCRIPTION
On systems without an ethernet interface (like the Raspberry Pi Zero) the `dhcp` program goes into a crash loop because it can't find eth0.

This PR adds an initial loop to wait for the given interface name to appear before continuing with the rest of the program.

**NOTE**: Unfortunately I can't fully test this code because I don't have any ethernet dongle; on a plain Raspberry Pi Zero 2 W it works fine: the `dhcp` process is not crash looping anymore.

Fixes #144