### PR TITLE
fix waitforclock condition when creating a new service

### DIFF
--- a/gokrazy.go
+++ b/gokrazy.go
@@ -404,7 +404,7 @@ func NewStoppedService(cmd *exec.Cmd) *Service {
 // NewWaitForClockService is like NewService, but the created gokrazy service
 // will wait for clock to be synchronized, i.e. blocked till the clock is accurate.
 func NewWaitForClockService(cmd *exec.Cmd) *Service {
-	return newService(cmd, true, true)
+	return newService(cmd, false, true)
 }
 
 // Supervise runs SuperviseServices, creating services from commands.


### PR DESCRIPTION
WaitForClock condition doesn't make sense to have on a Stopped service.

This change in behavior happened due to [this commit](https://github.com/gokrazy/gokrazy/commit/7e14fb215c2487a0507124e742f847dac22e1df2) which fixes the panic.