### PR TITLE
Add waiw to "Written for gokrazy"

### DIFF
--- a/website/content/packages/showcase.markdown
+++ b/website/content/packages/showcase.markdown
@@ -57,6 +57,12 @@ HTTP server that implements restic's REST backend API. Running it requires some
 setup and other configurations which are available in
 [this blog post](https://dcpri.me/2022/08/31/restic-rest-server-gokrazy/).
 
+### waiw
+
+[**waiw**](https://github.com/BrunoTeixeira1996/waiw) is a Go webserver to store 
+movies/series/animes ratings and comments. Running it requires some setup but the
+README describes every step to make it work.
+
 ## Successfully tested
 
 The following third-party programs have been successfully used with gokrazy

--- a/website/content/userguide/rsync-backups.markdown
+++ b/website/content/userguide/rsync-backups.markdown
@@ -77,11 +77,7 @@ dont_namespace = true
 EOT
 ```
 
-(Note that `scan2drive.lan` is the name of my gokrazy instance. I added the IP of the instance and defined a name in `/etc/hosts`, i.e `192.168.10.2 scan2drive.lan`)
-
 Finally, create the authorized keys file that determines who can access the rsync daemon:
-
-(i.e `ssh-keygen -t ed25519 -C "michael@midna.com"`, save in `~/.ssh/id_ed25519_scan2drivebackup` and cat the `.pub` key to `gokr-rsyncd.authorized_keys`)
 
 ```bash
 cat > ~/gokrazy/hello/gokr-rsyncd.authorized_keys <<'EOT'

--- a/website/content/userguide/rsync-backups.markdown
+++ b/website/content/userguide/rsync-backups.markdown
@@ -77,7 +77,11 @@ dont_namespace = true
 EOT
 ```
 
+(Note that `scan2drive.lan` is the name of my gokrazy instance. I added the IP of the instance and defined a name in `/etc/hosts`, i.e `192.168.10.2 scan2drive.lan`)
+
 Finally, create the authorized keys file that determines who can access the rsync daemon:
+
+(i.e `ssh-keygen -t ed25519 -C "michael@midna.com"`, save in `~/.ssh/id_ed25519_scan2drivebackup` and cat the `.pub` key to `gokr-rsyncd.authorized_keys`)
 
 ```bash
 cat > ~/gokrazy/hello/gokr-rsyncd.authorized_keys <<'EOT'


### PR DESCRIPTION
I use this project daily to store movies that I watch with my gf but since I have a gokrazy instance up and running I decided to make it possible to run in gokrazy too.
This works easily by just using a postgresql service running somewhere outside the gokrazy env.
Decided to make this as an example to the `Written for gokrazy` as this works with and without gokrazy.