### PR TITLE
Change how status is displayed

### DIFF
--- a/internal/assets/overview.tmpl
+++ b/internal/assets/overview.tmpl
@@ -8,18 +8,23 @@
 <table class="table">
 <tbody><tr>
 <th width="20%">path</th>
-<th width="80%">last log line</th>
+<th width="8%">status</th>
+<th width="72%">last log line</th>
 </tr>
 
 {{ range $idx, $svc := .Services }}
 <tr>
 <td>
 <a href="/status?path={{ $svc.Name }}">{{ $svc.Name }}</a>
+</td>
+<td>
 {{ if restarting $svc.Started }}
 <span class="label label-danger">restarting</span>
 {{ end }}
 {{ if $svc.Stopped }}
-<span class="label label-warning">stopped</span>
+<span class="label label-default">stopped</span>
+{{ else if not (restarting $svc.Started) }}
+<span class="label label-success">running</span>
 {{ end }}
 </td>
 <td class="lastlog">


### PR DESCRIPTION
Currently the status is appended to the service status link and no label
is displayed if the service is running. The status stopped is displayed
with a warning color (yellow). To me this feels uneven and a bit chaotic
which makes it harder to get a good overview and find a service.

This does three things to improve the overview:
- Add a separate column for status label. This takes a bit of width away
  from the last log line.
- Color the stopped label less aggressive (gray/default instead of
  yellow/warning).
- Add a green label for running service.

Potential improvements for the future could be to show if a service is
enabled/supervised or adding actions like start/stop/restart/enable.
