### PR TITLE
update go.mod replace directive link

### DIFF
--- a/website/content/_index.markdown
+++ b/website/content/_index.markdown
@@ -48,7 +48,7 @@ advantages you get when building Go software elsewhere:
   and [profiling](https://go.dev/blog/pprof) support can be used on the entire
   system
 * With Go’s [replace
-  directive](https://github.com/golang/go/wiki/Modules#when-should-i-use-the-replace-directive),
+  directive](https://go.dev/wiki/Modules#when-should-i-use-the-replace-directive),
   you can quickly modify any part of the system with the same workflow.
 
 ## Web status interface


### PR DESCRIPTION
Go wiki was moved from GitHub to go.dev. Original link now says:

> The Go wiki on GitHub has moved to go.dev (#61940).
> Try https://go.dev/wiki/Modules or https://go.dev/wiki/.
