### PR TITLE
ntp: Allow alternative NTP servers as arguments

### DIFF
--- a/cmd/ntp/ntp.go
+++ b/cmd/ntp/ntp.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"math/rand"
 	"os"
@@ -39,6 +40,13 @@ func set(rtc *os.File) error {
 
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	flag.Parse()
+
+	if len(flag.Args()) > 0 {
+		servers = flag.Args()
+		log.Printf("using command line supplied server list: %v", servers)
+	}
 
 	var rtc *os.File
 	var err error

--- a/cmd/ntp/privdrop.go
+++ b/cmd/ntp/privdrop.go
@@ -67,7 +67,7 @@ func mustDropPrivileges(rtc *os.File) {
 		log.Fatalf("SYS_CAPSET: %v", errno)
 	}
 
-	cmd := exec.Command(os.Args[0])
+	cmd := exec.Command(os.Args[0], os.Args[1:]...)
 	cmd.Env = append(os.Environ(), "NTP_PRIVILEGES_DROPPED=1")
 	if rtc != nil {
 		cmd.Env = append(cmd.Env, "NTP_RTC=1")


### PR DESCRIPTION
When the gokrazy deployment doesn't have internet access and the network lacks NTP traffic re-routing to the local time servers, instances may either have downright wrong clock (e.g. Raspberry Pi with no RTC) or experience divergence due to drift.

This add the ability to override the default NTP Pool Vendor Zone for gokrazy with servers supplied as command line arguments.

e.g.
```
    "PackageConfig": {
        "github.com/gokrazy/gokrazy/cmd/ntp": {
            "CommandLineFlags": [
                "time1.local" "time2.local" "10.1.2.123"
            ]
        }
    }
```