### PR TITLE
Fixes wrong link in quickstart section to permanent data (macOS note section)

### DIFF
--- a/website/content/quickstart/_index.markdown
+++ b/website/content/quickstart/_index.markdown
@@ -27,7 +27,7 @@ go install github.com/gokrazy/tools/cmd/gok@main
 
 ## Step 1: Insert an SD card
 
-Run `watch -d1 ls -l '/dev/disk/by-id/*'` (see the [permanent data section](https://gokrazy.org/userguide/permanent-data/section) for macOS instructions)
+Run `watch -d1 ls -l '/dev/disk/by-id/*'` (see the [permanent data section](/userguide/permanent-data/#notes-about-macos) for macOS instructions)
 and insert an SD card. Copy the highlighted device name:
 
 <script id="asciicast-G0PosAYGvUSnB3htMpLIz0p68" src="https://asciinema.org/a/G0PosAYGvUSnB3htMpLIz0p68.js" async></script>


### PR DESCRIPTION
Apologies for the typo. 