### PR TITLE
Update mount.go

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -114,7 +114,7 @@ func mountfs() error {
 	}
 
 	dev := rootdev.Partition(rootdev.Perm)
-	for _, fstype := range []string{"ext4", "vfat"} {
+	for _, fstype := range []string{"ext4", "vfat", "bcachefs"} {
 		if err := syscall.Mount(dev, "/perm", fstype, 0, ""); err != nil {
 			log.Printf("Could not mount permanent storage partition %s as %s: %v", dev, fstype, err)
 		} else {


### PR DESCRIPTION
Support mounting bcachefs formatted partitions to `/perm`. See https://github.com/gokrazy/kernel/pull/584