### PR TITLE
Perform poweroff instead of halt for 32-bit arch

### DIFF
--- a/halt.go
+++ b/halt.go
@@ -1,0 +1,17 @@
+//go:build !arm
+// +build !arm
+
+package gokrazy
+
+import (
+	"log"
+
+	"golang.org/x/sys/unix"
+)
+
+func halt() {
+	log.Println("Halting")
+	if err := unix.Reboot(unix.LINUX_REBOOT_CMD_HALT); err != nil {
+		log.Printf("HALT: %v", err)
+	}
+}

--- a/halt_arm.go
+++ b/halt_arm.go
@@ -1,0 +1,7 @@
+package gokrazy
+
+// LINUX_REBOOT_CMD_HALT is a uint32 constant that cannot be passed in as an int param on 32-bit systems.
+// This is a workaround to allow the code to compile on 32-bit systems and function nearly the same.
+func halt() {
+	poweroff()
+}

--- a/signals.go
+++ b/signals.go
@@ -8,6 +8,13 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func poweroff() {
+	log.Println("Powering off")
+	if err := unix.Reboot(unix.LINUX_REBOOT_CMD_POWER_OFF); err != nil {
+		log.Printf("POWER_OFF: %v", err)
+	}
+}
+
 func listenForSignals(sighup func()) {
 	{
 		c := make(chan os.Signal, 1)
@@ -33,17 +40,10 @@ func listenForSignals(sighup func()) {
 					reboot(true)
 
 				case unix.SIGUSR1:
-					log.Println("Halting")
-					if err := unix.Reboot(unix.LINUX_REBOOT_CMD_HALT); err != nil {
-						log.Printf("HALT: %v", err)
-					}
+					halt()
 
 				case unix.SIGUSR2:
-					log.Println("Powering off")
-					if err := unix.Reboot(unix.LINUX_REBOOT_CMD_POWER_OFF); err != nil {
-						log.Printf("POWER_OFF: %v", err)
-					}
-
+					poweroff()
 				}
 			}
 		}()


### PR DESCRIPTION
LINUX_REBOOT_CMD_HALT is higher than int32 MAX and doesn't compile as an int on 32-bit systems. Ideally, unix.Reboot would take a uint.