### PR TITLE
Implement options for MountDevices

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -246,7 +246,11 @@ func mountDevice(md config.MountDevice) error {
 		return err
 	}
 
-	log.Printf("mounting %s on %s", dev, md.Target)
+	options := ""
+	if md.Options != "" {
+		options = " with options: " + md.Options
+	}
+	log.Printf("mounting %s on %s%s", dev, md.Target, options)
 	if err := syscall.Mount(dev, md.Target, md.Type, 0, ""); err != nil {
 		return err
 	}


### PR DESCRIPTION
This implements the last bit of functionality for #236, using the same logic as moby/sys/mount. I added the options to the log message when they're present, omitting the text when empty.

The moby library has a `defaults` entry in the flags table for completeness, but it gets incorrectly passed down as filesystem-specific data. I decided to just remove it, since defaults are by definition the default.

To test, I built one of my instances with this branch and added an ISO mount to the qemu command I use to test on my laptop:
```
qemu-system-x86_64 \
	-machine accel=kvm \
	-smp 8 \
	-m 2048 \
	-device virtio-blk-pci,drive=hd \
	-drive if=none,id=hd,file=qemu.img,format=raw \
	-device virtio-blk-pci,drive=cd \
	-drive if=none,id=cd,file=metadata.iso,format=raw \      <-- here
	-nographic \
	-netdev user,id=diag,hostfwd=tcp:127.0.0.1:1080-:1080,hostfwd=tcp:127.0.0.1:8080-:80,hostfwd=tcp:127.0.0.1:2222-:22 \
	-device e1000,netdev=diag
```
And configured a mount with a couple options:
```
    "MountDevices": [
		{
		    "Source": "/dev/vdb",
		    "Type": "iso9660",
		    "Target": "/mnt/cd",
		    "Options": "ro,noexec"
		}
	]
```

It was able to mount it:
```
[    1.560598] Run /gokrazy/init as init process
gokrazy build timestamp 2024-07-20T16:46:37-04:00
2024/07/20 16:46:48 gokrazy.go:62: disabling hardware watchdog, as it could not be opened: open /dev/watchdog: no such file or directory
2024/07/20 16:46:49 rootdev.go:60: findGPTPartUUID: open /dev/sr0: no medium found
[    1.721255] EXT4-fs (vda4): mounted filesystem ab25de23-a7d0-4bdf-911b-3227362b83b8 r/w with ordered data mode. Quota mode: none.
2024/07/20 16:46:49 mount.go:322: mounting /dev/vdb on /mnt/cd with options: ro,noexec
...

2024/07/20 16:46:52 gokrazy.go:366: starting shell /tmp/serial-busybox/ash upon input on serial console
/ # mount
/dev/root on / type squashfs (ro,relatime,errors=continue)
devtmpfs on /dev type devtmpfs (rw,relatime,size=1005520k,nr_inodes=251380,mode=755)
tmpfs on /tmp type tmpfs (rw,nosuid,nodev,relatime)
devpts on /dev/pts type devpts (rw,relatime,mode=600,ptmxmode=000)
tmpfs on /dev/shm type tmpfs (rw,relatime)
tmpfs on /run type tmpfs (rw,relatime)
proc on /proc type proc (rw,relatime)
sysfs on /sys type sysfs (rw,relatime)
/dev/vda4 on /perm type ext4 (rw,relatime)
cgroup2 on /sys/fs/cgroup type cgroup2 (rw,relatime)
/dev/vdb on /mnt/cd type iso9660 (ro,noexec,relatime,nojoliet,check=s,map=n,blocksize=2048,iocharset=utf8)
```

Whereas without `ro` it fails because the underlying filesystem is indeed read only:
```
    "MountDevices": [
		{
		    "Source": "/dev/vdb",
		    "Type": "iso9660",
		    "Target": "/mnt/cd",
		    "Options": ""
		}
	]
```
```
2024/07/20 16:50:15 mount.go:322: mounting /dev/vdb on /mnt/cd
2024/07/20 16:50:15 mount.go:355: mounting /dev/vdb: permission denied
```

I haven't actually tested the filesystem-specific data with a real supported flag, but used debug logging during development to verify that it indeed gets reassembled properly and passed along. It's being interpreted correctly by the underlying kernel module:
```
mount.go:321: mounting /dev/vdb on /mnt/cd with options: ro,banana,noexec,some_nonsense
2024/07/20 17:00:52 mount.go:322: data banana,some_nonsense
[    1.712084] iso9660: Unknown parameter 'banana'
2024/07/20 17:00:52 mount.go:355: mounting /dev/vdb: invalid argument
```