### PR TITLE
Document GOKRAZY_PARENT_DIR

### DIFF
--- a/docs/quickstart/index.html
+++ b/docs/quickstart/index.html
@@ -845,7 +845,9 @@ and insert an SD card. Copy the highlighted device name:</p>
 <div class="highlight"><pre tabindex="0" style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4;"><code class="language-bash" data-lang="bash"><span style="display:flex;"><span>gok new
 </span></span><span style="display:flex;"><span><span style="color:#75715e"># creates an instance named “hello” in --parent_dir default directory ~/gokrazy</span>
 </span></span><span style="display:flex;"><span><span style="color:#75715e"># alternatively, to use a different instance name: gok -i myname new</span>
-</span></span></code></pre></div><p>If you’re curious, you can run <code>gok edit</code> to open the generated <code>config.json</code> in
+</span></span></code></pre></div><p>The <code>--parent_dir</code> can also be changed permanently by setting the
+<code>GOKRAZY_PARENT_DIR</code> environment variable.</p>
+<p>If you’re curious, you can run <code>gok edit</code> to open the generated <code>config.json</code> in
 your editor.</p>
 <p>To overwrite the entire SD card <code>/dev/sdx</code> with a build of this
 gokrazy installation, use:</p>

--- a/website/content/quickstart/_index.markdown
+++ b/website/content/quickstart/_index.markdown
@@ -44,6 +44,9 @@ gok new
 # alternatively, to use a different instance name: gok -i myname new
 ```
 
+The `--parent_dir` can also be changed permanently by setting the
+`GOKRAZY_PARENT_DIR` environment variable.
+
 If you’re curious, you can run `gok edit` to open the generated `config.json` in
 your editor.
 


### PR DESCRIPTION
As a non-conformist, I needed to move my instances elsewhere and had to discover this variable via the code. :)

I explicitly added just the relevant parts of what Hugo generated, regenerating the entire site touches a lot of files due to changes in generation in the latest releases. If you do want to do the full rebuild I'm happy to change this PR.

The current release is also unhappy with the site in general:
```
ERROR deprecated: .Site.IsMultiLingual was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.142.0. Use hugo.IsMultilingual instead.
```

I'm not sure how/if you'd like to handle this; I can open another issue if you want to track upgrading, or update the README to specify a version. Either way I figured it's out of scope for this PR.

Fixes #222.