### PR TITLE
Always listen on the GokrazyHTTPUnixSocket

### DIFF
--- a/authenticated.go
+++ b/authenticated.go
@@ -17,7 +17,7 @@ func authenticated(w http.ResponseWriter, r *http.Request) {
 	// See https://github.com/gokrazy/gokrazy/issues/265
 	if httpPassword == "" {
 		addr, ok := r.Context().Value(http.LocalAddrContextKey).(*net.UnixAddr)
-		if ok && addr.Name == GokrazyHTTPUnixSocket {
+		if ok && addr.Name == HTTPUnixSocket {
 			http.DefaultServeMux.ServeHTTP(w, r)
 		} else {
 			http.Error(w, "httpPassword not set and request from unexpected address", http.StatusInternalServerError)

--- a/authenticated.go
+++ b/authenticated.go
@@ -15,9 +15,9 @@ func authenticated(w http.ResponseWriter, r *http.Request) {
 	// verify that's where it came from.
 	//
 	// See https://github.com/gokrazy/gokrazy/issues/265
-	if httpPassword == "" {
-		addr, ok := r.Context().Value(http.LocalAddrContextKey).(*net.UnixAddr)
-		if ok && addr.Name == GokrazyHTTPUnixSocket {
+	addr, ok := r.Context().Value(http.LocalAddrContextKey).(*net.UnixAddr)
+	if ok {
+		if addr.Name == GokrazyHTTPUnixSocket {
 			http.DefaultServeMux.ServeHTTP(w, r)
 		} else {
 			http.Error(w, "httpPassword not set and request from unexpected address", http.StatusInternalServerError)

--- a/authenticated.go
+++ b/authenticated.go
@@ -15,9 +15,9 @@ func authenticated(w http.ResponseWriter, r *http.Request) {
 	// verify that's where it came from.
 	//
 	// See https://github.com/gokrazy/gokrazy/issues/265
-	addr, ok := r.Context().Value(http.LocalAddrContextKey).(*net.UnixAddr)
-	if ok {
-		if addr.Name == GokrazyHTTPUnixSocket {
+	if httpPassword == "" {
+		addr, ok := r.Context().Value(http.LocalAddrContextKey).(*net.UnixAddr)
+		if ok && addr.Name == GokrazyHTTPUnixSocket {
 			http.DefaultServeMux.ServeHTTP(w, r)
 		} else {
 			http.Error(w, "httpPassword not set and request from unexpected address", http.StatusInternalServerError)

--- a/authenticated.go
+++ b/authenticated.go
@@ -17,7 +17,7 @@ func authenticated(w http.ResponseWriter, r *http.Request) {
 	// See https://github.com/gokrazy/gokrazy/issues/265
 	if httpPassword == "" {
 		addr, ok := r.Context().Value(http.LocalAddrContextKey).(*net.UnixAddr)
-		if ok && addr.Name == gokrazyHTTPUnixSocket {
+		if ok && addr.Name == GokrazyHTTPUnixSocket {
 			http.DefaultServeMux.ServeHTTP(w, r)
 		} else {
 			http.Error(w, "httpPassword not set and request from unexpected address", http.StatusInternalServerError)

--- a/listeners.go
+++ b/listeners.go
@@ -43,8 +43,8 @@ var (
 	listeners   = make(map[string][]*krazyServer) // by unix socket path and private IP address
 )
 
-// GokrazyHTTPUnixSocket is the unix socket path that the HTTP server listens on.
-const GokrazyHTTPUnixSocket = "/run/gokrazy-http.sock"
+// HTTPUnixSocket is the unix socket path that the HTTP server listens on.
+const HTTPUnixSocket = "/run/gokrazy-http.sock"
 
 // tlsConfig: tlsConfig. nil, if the listeners should not use https (e.g. for redirects)
 func updateListeners(port, redirectPort string, tlsEnabled bool, tlsConfig *tls.Config) error {
@@ -58,7 +58,7 @@ func updateListeners(port, redirectPort string, tlsEnabled bool, tlsConfig *tls.
 	// If NoPassword is used, the HTTP server doesn't run over HTTP
 	// and instead only listens on a Unix socket. Packages running
 	// in the appliance can proxy to the Unix socket as desired.
-	hosts := []string{GokrazyHTTPUnixSocket}
+	hosts := []string{HTTPUnixSocket}
 	if httpPassword != "" {
 		addrs, err := PrivateInterfaceAddrs()
 		if err != nil {
@@ -120,7 +120,7 @@ func updateListeners(port, redirectPort string, tlsEnabled bool, tlsConfig *tls.
 		}
 		// add a new listener
 		var srv *http.Server
-		if tlsEnabled && tlsConfig == nil && host != GokrazyHTTPUnixSocket {
+		if tlsEnabled && tlsConfig == nil && host != HTTPUnixSocket {
 			// "Redirect" server
 			srv = &http.Server{
 				Handler:   http.HandlerFunc(httpsRedirect(redirectPort)),

--- a/listeners.go
+++ b/listeners.go
@@ -50,10 +50,9 @@ const HTTPUnixSocket = "/run/gokrazy-http.sock"
 func updateListeners(port, redirectPort string, tlsEnabled bool, tlsConfig *tls.Config) error {
 	// Always listen on a Unix socket.
 	//
-	// Local packages running as root can connect through the Unix socket
-	// regardless of TLS settings. With TLS enabled: Avoids the complexity
-	// of certificate validation. Without TLS: Provides security through
-	// Unix file system permissions.
+	// Local processes running as root can connect through the Unix socket,
+	// which removes the complexity of connecting via HTTP+TCP (which might
+	// need a custom port, or TLS credentials).
 	//
 	// If NoPassword is used, the HTTP server doesn't run over HTTP
 	// and instead only listens on a Unix socket. Packages running


### PR DESCRIPTION
The change is made to allow other tools like [breakglass](https://github.com/gokrazy/breakglass) or [mkfs](https://github.com/gokrazy/mkfs) to interact with the Gokrazy API when TLS is enabled. The tools currently make HTTP requests to get system information or trigger reboots. When TLS is enabled, these requests fail because Gokrazy redirects all HTTP requests to HTTPS. While it is possible to configure the respective clients to properly validate (self-signed) certificates, doing so is cumbersome. Therefore, always listen on the Unix socket to avoid the complexity of certificate validation. Username and password must still be provided and will be validated.

I've considered removing the username and password validation for socket requests. However, I've decided to reverse the change and keep everything as it is for now, in part to keep changes to a minimum. I can see arguments for and against removing the checks, and I don't feel strongly one way or the other.

The `GokrazyHTTPUnixSocket` constant is exported so that tools can reference it instead of hardcoding the path.

Ref https://github.com/gokrazy/breakglass/issues/21