### PR TITLE
Automatically set USER to root if not already set

### DIFF
--- a/supervise.go
+++ b/supervise.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -472,6 +473,17 @@ func supervise(s *service) {
 			// Process execution fails when cmd.Dir points to
 			// a non-existant directory.
 			cmd.Dir = homeDir
+		}
+
+		// If $USER isn't already set, set it to root
+		// in order to further increase the chance of daemons
+		// working properly out of the box
+		hasUser := slices.ContainsFunc(cmd.Env, func(s string) bool {
+			return strings.HasPrefix(s, "USER=")
+		})
+
+		if !hasUser {
+			cmd.Env = append(cmd.Env, "USER=root")
 		}
 
 		l.Printf("gokrazy: attempt %d, starting %q", attempt, cmd.Args)


### PR DESCRIPTION
I included a check to make sure we don't overwrite something that's already set. We don't seem to do that for $HOME, but I think users are much more likely to want to override $USER than $HOME.

Ref #320