### PR TITLE
web interface: add power management buttons

### DIFF
--- a/internal/assets/header.tmpl
+++ b/internal/assets/header.tmpl
@@ -69,6 +69,19 @@ table {
           <td>{{ shortenSHA256 .EEPROM.PieepromSHA256 }}<br>{{ shortenSHA256 .EEPROM.VL805SHA256 }}</td>
         </tr>
         {{ end }}
+        <tr>
+          <td></td>
+          <td>
+            <details>
+              <summary style="display: revert;margin-left: -1.25rem;">Power Management</summary>
+              <form action="/reboot" method="post" style="display:inline">
+                <button type="submit">Reboot</button>
+              </form>
+              <form action="/poweroff" method="post" style="display:inline">
+                <button type="submit">Poweroff</button>
+              </form>
+            </details>
+          </td>
       </table>
 
     </div><!-- /.navbar-collapse -->


### PR DESCRIPTION
This PR adds a basic menu at the top right of the web interface to easily shutdown gokrazy (useful to prevent SD-Card corruption when unplugging the board).
<img width="588" height="297" alt="image" src="https://github.com/user-attachments/assets/050bc26a-592b-41aa-9917-049007589829" />
<img width="588" height="297" alt="image" src="https://github.com/user-attachments/assets/fbd17ac3-db43-43a7-a52c-c77df48e74ea" />
