### PR TITLE
Fix small typo in instance-config.md

### DIFF
--- a/website/content/userguide/instance-config.md
+++ b/website/content/userguide/instance-config.md
@@ -786,7 +786,7 @@ included in the boot file system of your gokrazy instance:
 
 - `pieeprom-*.bin`, Raspberry Pi EEPROM update files
 - `recovery.bin`, Raspberry Pi EEPROM update files
-- `lv805-*.bin`, Raspberry Pi EEPROM update files
+- `vl805-*.bin`, Raspberry Pi EEPROM update files
 
 Default if unset: `github.com/gokrazy/rpi-eeprom`
 


### PR DESCRIPTION
See e.g. https://github.com/raspberrypi/rpi-eeprom/tree/master/firmware-2711/default for the names of these `*.bin` files