### PR TITLE
dhcp: os.Exit(125) after applying static config

### DIFF
--- a/cmd/dhcp/dhcp.go
+++ b/cmd/dhcp/dhcp.go
@@ -410,8 +410,8 @@ func main() {
 		if err := applyLease(nl, *ifname, lsrc, l, *extraRoutePriority); err != nil {
 			log.Fatal(err)
 		}
-		// Leave the process running indefinitely
-		time.Sleep(time.Duration(1<<63 - 1))
+		log.Print("Static config applied successfully; exiting.")
+		os.Exit(125)
 	}
 
 	conn, err := packet.Listen(intf, packet.Datagram, unix.ETH_P_IP, nil)


### PR DESCRIPTION
Rationale: saves ~16.6MiB of RSS and mildly simplifies the operating conditions of a gokrazy appliance.
Before: `892.4 MiB total, 808.1 MiB available`
After: `892.4 MiB total, 824.7 MiB available`

(cf. https://github.com/gokrazy/gokrazy/discussions/354#discussioncomment-15421711)