### PR TITLE
Add WaitFor in config.json to wait for network before starting services

### DIFF
--- a/gokrazy.go
+++ b/gokrazy.go
@@ -417,6 +417,11 @@ func NewWaitForClockService(cmd *exec.Cmd) *Service {
 	return newService(cmd, false, true)
 }
 
+// SetWaitFor sets the conditions to wait for before starting the service.
+func (s *Service) SetWaitFor(waitFor []string) {
+	s.s.waitFor = waitFor
+}
+
 // Supervise runs SuperviseServices, creating services from commands.
 //
 // Deprecated: newer versions of gokr-packer run gokrazy.SuperviseServices()

--- a/gokrazy_test.go
+++ b/gokrazy_test.go
@@ -1,0 +1,25 @@
+package gokrazy
+
+import (
+	"os/exec"
+	"reflect"
+	"testing"
+)
+
+func TestSetWaitFor(t *testing.T) {
+	cmd := exec.Command("true")
+	s := NewService(cmd)
+
+	// Check initial state
+	if len(s.s.waitFor) != 0 {
+		t.Errorf("expected initial waitFor to be empty, got %v", s.s.waitFor)
+	}
+
+	// Set waitFor
+	waitItems := []string{"clock", "net-online"}
+	s.SetWaitFor(waitItems)
+
+	if !reflect.DeepEqual(s.s.waitFor, waitItems) {
+		t.Errorf("expected waitFor to be %v, got %v", waitItems, s.s.waitFor)
+	}
+}

--- a/supervise.go
+++ b/supervise.go
@@ -205,6 +205,7 @@ type service struct {
 	supervision   supervisionMode
 
 	waitForClock bool
+	waitFor      []string
 
 	state *processState
 }
@@ -414,6 +415,11 @@ func supervise(s *service) {
 	if strings.HasPrefix(s.Cmd().Path, "/user/") && s.waitForClock {
 		l.Print("gokrazy: waiting for clock to be synced")
 		WaitForClock()
+	}
+
+	if strings.HasPrefix(s.Cmd().Path, "/user/") && len(s.waitFor) > 0 {
+		l.Printf("gokrazy: waiting for %v", s.waitFor)
+		WaitFor(s.waitFor...)
 	}
 
 	for {

--- a/wait_test.go
+++ b/wait_test.go
@@ -1,0 +1,36 @@
+package gokrazy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWaitForSleep(t *testing.T) {
+	start := time.Now()
+	waitForSleep("10ms")
+	elapsed := time.Since(start)
+
+	if elapsed < 10*time.Millisecond {
+		t.Errorf("expected sleep to last at least 10ms, got %v", elapsed)
+	}
+}
+
+
+func TestWaitFor(t *testing.T) {
+	// Test that it doesn't panic on known values
+	// We can't really test the waiting behaviour easily without blocking,
+	// but we can test "sleep=0s" which should return immediately.
+
+	start := time.Now()
+	WaitFor("sleep=1ms")
+	elapsed := time.Since(start)
+	if elapsed < 1*time.Millisecond {
+		t.Errorf("WaitFor(sleep=1ms): expected at least 1ms, got %v", elapsed)
+	}
+
+	// Test "interface=lo" (localhost should be up)
+	start = time.Now()
+	WaitFor("interface=lo")
+	// This usually returns instantly if lo is up.
+	// We can't easily assert on time, but ensuring it doesn't hang forever or panic is good.
+}

--- a/wait_test.go
+++ b/wait_test.go
@@ -15,7 +15,6 @@ func TestWaitForSleep(t *testing.T) {
 	}
 }
 
-
 func TestWaitFor(t *testing.T) {
 	// Test that it doesn't panic on known values
 	// We can't really test the waiting behaviour easily without blocking,

--- a/website/content/userguide/instance-config.md
+++ b/website/content/userguide/instance-config.md
@@ -420,6 +420,47 @@ permanently running services.
 }
 {{< /highlight >}}
 
+### PackageConfig → WaitFor {#packagewaitfor}
+
+(No correspondence to former per-package directory text files.)
+
+The `WaitFor` field makes the gokrazy init system wait for the specified conditions
+to be met before starting the program. This is useful when you want to ensure
+the network is ready, or the clock is synchronized, but modifying the program source
+to call [`gokrazy.WaitFor()`](https://pkg.go.dev/github.com/gokrazy/gokrazy#WaitFor)
+is inconvenient.
+
+The available conditions are:
+
+*   `"clock"`: Wait for the system clock to be set (via NTP).
+*   `"net-route"`: Wait for a default route to be installed (local network via DHCP).
+*   `"net-online"`: Wait for internet connectivity (ping gokrazy.org).
+*   `"interface=<ifname>"`: Wait for the specified network interface to be up (e.g. `interface=tailscale0`).
+*   `"sleep=<duration>"`: Wait for the specified duration (e.g. `sleep=5s`).
+
+**Example:**
+
+{{< highlight json "hl_lines=10-18" >}}
+{
+    "Hostname": "scanner",
+    "Packages": [
+        "github.com/gokrazy/fbstatus",
+        "github.com/gokrazy/hello",
+        "github.com/gokrazy/serial-busybox",
+        "github.com/gokrazy/breakglass",
+        "github.com/evcc-io/evcc"
+    ],
+    "PackageConfig": {
+        "github.com/evcc-io/evcc": {
+            "WaitFor": [
+                "clock",
+                "interface=tailscale0"
+            ]
+        }
+    }
+}
+{{< /highlight >}}
+
 ### PackageConfig → WaitForClock {#packagewaitforclock}
 
 (Corresponds to the former `waitforclock` per-package directory text files.)
@@ -549,7 +590,7 @@ handled as if you had configured `ExtraFilePaths:
 cat > ~/gokrazy/webserver/Caddyfile <<'EOT'
 http://:80 {
 	root * /tmp
-	file_server browse 
+	file_server browse
 }
 EOT
 ```


### PR DESCRIPTION
- add PackageConfig WaitFor field and Service.SetWaitFor
- add wait targets for sleep and interface

Fixes #357.

Co-authored-by: Github Copilot <>

Note: updating gok is required for this to work. gokrazy/tools#96 .

Main discussion in #357 .