### PR TITLE
cmd/ntp: preserve system time in /perm.

### DIFF
--- a/cmd/ntp/ntp.go
+++ b/cmd/ntp/ntp.go
@@ -3,20 +3,34 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"io"
 	"log"
 	"math/rand"
 	"os"
+	"os/signal"
 	"syscall"
 	"time"
 
 	"github.com/beevik/ntp"
 )
 
+const cookiePath = "/perm/.ntp-time-at-last-shutdown"
+
 var servers = []string{
 	"0.gokrazy.pool.ntp.org",
 	"1.gokrazy.pool.ntp.org",
 	"2.gokrazy.pool.ntp.org",
 	"3.gokrazy.pool.ntp.org",
+}
+
+func setTimeOfDay(t time.Time, source string) error {
+	tv := syscall.NsecToTimeval(t.UnixNano())
+	if err := syscall.Settimeofday(&tv); err != nil {
+		return fmt.Errorf("syscall.Settimeofday(%v): %v", tv, err)
+	}
+	log.Printf("clock set to %v (from %s)", t, source)
+	return nil
 }
 
 func set(rtc *os.File) error {
@@ -26,16 +40,46 @@ func set(rtc *os.File) error {
 		return err
 	}
 
-	tv := syscall.NsecToTimeval(r.Time.UnixNano())
-	if err := syscall.Settimeofday(&tv); err != nil {
-		return err
+	if err := setTimeOfDay(r.Time, server); err != nil {
+		return fmt.Errorf("setTimeOfDay: %v", err)
 	}
-	log.Printf("clock set to %v (from %s)", r.Time, server)
 
 	if rtc == nil {
 		return nil
 	}
 	return setRTC(rtc, r.Time.UTC())
+}
+
+func loadTime(cookie *os.File) error {
+	buf, err := io.ReadAll(cookie)
+	if err != nil {
+		return fmt.Errorf("io.ReadAll(%v): %v", cookiePath, err)
+	}
+	var t time.Time
+	if err := t.UnmarshalText(buf); err != nil {
+		return fmt.Errorf("t.UnmarshalText(%v): %v", string(buf), err)
+	}
+	if err := setTimeOfDay(t, cookiePath); err != nil {
+		return fmt.Errorf("setTimeOfDay: %v", err)
+	}
+	return nil
+}
+
+func saveTime(cookie *os.File) error {
+	buf, err := time.Now().MarshalText()
+	if err != nil {
+		return fmt.Errorf("time.Now().MarshalText: %v", err)
+	}
+	if err := cookie.Truncate(0); err != nil {
+		return fmt.Errorf("cookie.Truncate: %v", err)
+	}
+	if _, err := cookie.Seek(0, 0); err != nil {
+		log.Printf("cookie.Seek(0, 0): %v", err)
+	}
+	if _, err := cookie.Write(buf); err != nil {
+		return fmt.Errorf("cookie.Write(%v): %v", buf, err)
+	}
+	return nil
 }
 
 func main() {
@@ -48,27 +92,61 @@ func main() {
 		log.Printf("using command line supplied server list: %v", servers)
 	}
 
-	var rtc *os.File
+	var rtc, cookie *os.File
 	var err error
 	if os.Getenv("NTP_PRIVILEGES_DROPPED") == "1" {
+		var nextFD uintptr = 3
 		if os.Getenv("NTP_RTC") == "1" {
-			rtc = os.NewFile(3, "/dev/rtc0")
+			rtc = os.NewFile(nextFD, "/dev/rtc0")
+			nextFD++
+		}
+		if os.Getenv("NTP_COOKIE") == "1" {
+			cookie = os.NewFile(nextFD, cookiePath)
+			nextFD++
 		}
 	} else {
 		rtc, err = os.Open("/dev/rtc0")
 		if err != nil && !os.IsNotExist(err) {
 			log.Fatal(err)
 		}
+		cookie, err = os.OpenFile(cookiePath, os.O_RDWR|os.O_CREATE, 0600)
+		if err != nil {
+			log.Printf("os.Open(%v): %v", cookiePath, err)
+		}
+		mustDropPrivileges(rtc, cookie) // Never returns.
 	}
 
-	mustDropPrivileges(rtc)
-
-	for {
-		jitter := time.Duration(rand.Int63n(250)) * time.Millisecond
-		if err := set(rtc); err != nil {
-			time.Sleep(jitter)
-			log.Fatalf("setting time failed: %v", err)
+	if cookie != nil {
+		// Save current time at shutdown.
+		go func() {
+			// Wait for SIGTERM to save time to /perm.
+			ch := make(chan os.Signal, 1)
+			signal.Notify(ch, syscall.SIGTERM)
+			defer func() {
+				signal.Reset(syscall.SIGTERM)
+				if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+					log.Fatalf("syscall.Kill(re-sending caught SIGTERM): %v", err)
+				}
+			}()
+			<-ch
+			if err := saveTime(cookie); err != nil {
+				log.Printf("persisting time to /perm failed: %v", err)
+			}
+		}()
+		// Load time saved at previous shutdown, if any.
+		if err := loadTime(cookie); err != nil {
+			log.Printf("loadTime: %v", err)
 		}
-		time.Sleep(1*time.Hour + jitter)
+	}
+
+	jitter := time.Duration(rand.Int63n(250)) * time.Millisecond
+	for {
+		time.Sleep(jitter)
+		if err := set(rtc); err != nil {
+			log.Printf("setting time failed: %v", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		time.Sleep(1 * time.Hour)
 	}
 }

--- a/cmd/ntp/ntp.go
+++ b/cmd/ntp/ntp.go
@@ -15,7 +15,7 @@ import (
 	"github.com/beevik/ntp"
 )
 
-const timefile = "ntp-time-at-last-shutdown" // Our process is started in /perm/home/ntp.
+const timefilePath = "ntp-time-at-last-shutdown" // Our process is started in /perm/home/ntp.
 
 var servers = []string{
 	"0.gokrazy.pool.ntp.org",
@@ -50,37 +50,37 @@ func set(rtc *os.File) error {
 	return setRTC(rtc, r.Time.UTC())
 }
 
-func loadTime(cookie *os.File) error {
-	buf, err := io.ReadAll(cookie)
+func loadTime(timefile *os.File) error {
+	buf, err := io.ReadAll(timefile)
 	if err != nil {
-		return fmt.Errorf("io.ReadAll(%v): %v", timefile, err)
+		return fmt.Errorf("io.ReadAll(%v): %v", timefilePath, err)
 	}
 	var t time.Time
 	if err := t.UnmarshalText(buf); err != nil {
-		return fmt.Errorf("t.UnmarshalText(%v): %v", string(buf), err)
+		return fmt.Errorf("time.UnmarshalText(%v): %v", string(buf), err)
 	}
-	if err := setTimeOfDay(t, timefile); err != nil {
+	if err := setTimeOfDay(t, timefilePath); err != nil {
 		return fmt.Errorf("setTimeOfDay: %v", err)
 	}
 	return nil
 }
 
-func saveTime(cookie *os.File) error {
+func saveTime(timefile *os.File) error {
 	buf, err := time.Now().MarshalText()
 	if err != nil {
 		return fmt.Errorf("time.Now().MarshalText: %v", err)
 	}
-	if err := cookie.Truncate(0); err != nil {
-		return fmt.Errorf("cookie.Truncate: %v", err)
+	if err := timefile.Truncate(0); err != nil {
+		return fmt.Errorf("timefile.Truncate: %v", err)
 	}
-	if _, err := cookie.Seek(0, 0); err != nil {
-		log.Printf("cookie.Seek(0, 0): %v", err)
+	if _, err := timefile.Seek(0, 0); err != nil {
+		log.Printf("timefile.Seek(0, 0): %v", err)
 	}
-	if _, err := cookie.Write(buf); err != nil {
-		return fmt.Errorf("cookie.Write(%v): %v", buf, err)
+	if _, err := timefile.Write(buf); err != nil {
+		return fmt.Errorf("timefile.Write(%v): %v", buf, err)
 	}
-	if err := cookie.Close(); err != nil {
-		return fmt.Errorf("cookie.Close: %v", err)
+	if err := timefile.Close(); err != nil {
+		return fmt.Errorf("timefile.Close: %v", err)
 	}
 	return nil
 }
@@ -95,7 +95,7 @@ func main() {
 		log.Printf("using command line supplied server list: %v", servers)
 	}
 
-	var rtc, cookie *os.File
+	var rtc, timefile *os.File
 	var err error
 	if os.Getenv("NTP_PRIVILEGES_DROPPED") == "1" {
 		var nextFD uintptr = 3
@@ -103,8 +103,8 @@ func main() {
 			rtc = os.NewFile(nextFD, "/dev/rtc0")
 			nextFD++
 		}
-		if os.Getenv("NTP_COOKIE") == "1" {
-			cookie = os.NewFile(nextFD, timefile)
+		if os.Getenv("NTP_TIMEFILE") == "1" {
+			timefile = os.NewFile(nextFD, timefilePath)
 			nextFD++
 		}
 	} else {
@@ -112,34 +112,37 @@ func main() {
 		if err != nil && !os.IsNotExist(err) {
 			log.Fatal(err)
 		}
-		cookie, err = os.OpenFile(timefile, os.O_RDWR|os.O_CREATE, 0600)
+		timefile, err = os.OpenFile(timefilePath, os.O_RDWR|os.O_CREATE, 0600)
 		if err != nil {
-			log.Printf("os.Open(%v): %v", timefile, err)
+			log.Printf("os.Open(%v): %v", timefilePath, err)
 		}
-		mustDropPrivileges(rtc, cookie) // Never returns.
+		mustDropPrivileges(rtc, timefile) // Never returns.
 	}
 
-	if cookie != nil {
+	if timefile != nil {
 		// Save current time at shutdown.
 		go func() {
 			// Wait for SIGTERM to save time to /perm.
 			ch := make(chan os.Signal, 1)
 			signal.Notify(ch, syscall.SIGTERM)
 			<-ch
-			if err := saveTime(cookie); err != nil {
+			if err := saveTime(timefile); err != nil {
 				log.Printf("persisting time to /perm failed: %v", err)
 			}
 			os.Exit(128 + int(syscall.SIGTERM))
 		}()
 		// Load time saved at previous shutdown, if any.
-		if err := loadTime(cookie); err != nil {
+		if err := loadTime(timefile); err != nil {
 			log.Printf("loadTime: %v", err)
 		}
 	}
 
-	jitter := time.Duration(rand.Int63n(250)) * time.Millisecond
 	for {
-		time.Sleep(jitter)
+		// Choose a different jitter in every iteration to minimize
+		// thundering herds when multiple hosts boot up without clock or
+		// network sources of entropy.
+		time.Sleep(time.Duration(rand.Int63n(250)) * time.Millisecond)
+
 		if err := set(rtc); err != nil {
 			log.Printf("setting time failed: %v", err)
 			time.Sleep(1 * time.Second)

--- a/cmd/ntp/privdrop.go
+++ b/cmd/ntp/privdrop.go
@@ -44,11 +44,7 @@ func getCaps() (caps, error) {
 // mustDropPrivileges executes the program in a child process, dropping root
 // privileges, but retaining the CAP_SYS_TIME capability to change the system
 // clock.
-func mustDropPrivileges(rtc *os.File) {
-	if os.Getenv("NTP_PRIVILEGES_DROPPED") == "1" {
-		return
-	}
-
+func mustDropPrivileges(rtc, cookie *os.File) {
 	// From include/uapi/linux/capability.h:
 	// Allow setting the real-time clock
 	const CAP_SYS_TIME = 25
@@ -71,7 +67,11 @@ func mustDropPrivileges(rtc *os.File) {
 	cmd.Env = append(os.Environ(), "NTP_PRIVILEGES_DROPPED=1")
 	if rtc != nil {
 		cmd.Env = append(cmd.Env, "NTP_RTC=1")
-		cmd.ExtraFiles = []*os.File{rtc}
+		cmd.ExtraFiles = append(cmd.ExtraFiles, rtc)
+	}
+	if cookie != nil {
+		cmd.Env = append(cmd.Env, "NTP_COOKIE=1")
+		cmd.ExtraFiles = append(cmd.ExtraFiles, cookie)
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/ntp/privdrop.go
+++ b/cmd/ntp/privdrop.go
@@ -44,7 +44,7 @@ func getCaps() (caps, error) {
 // mustDropPrivileges executes the program in a child process, dropping root
 // privileges, but retaining the CAP_SYS_TIME capability to change the system
 // clock.
-func mustDropPrivileges(rtc, cookie *os.File) {
+func mustDropPrivileges(rtc, timefile *os.File) {
 	// From include/uapi/linux/capability.h:
 	// Allow setting the real-time clock
 	const CAP_SYS_TIME = 25
@@ -69,9 +69,9 @@ func mustDropPrivileges(rtc, cookie *os.File) {
 		cmd.Env = append(cmd.Env, "NTP_RTC=1")
 		cmd.ExtraFiles = append(cmd.ExtraFiles, rtc)
 	}
-	if cookie != nil {
-		cmd.Env = append(cmd.Env, "NTP_COOKIE=1")
-		cmd.ExtraFiles = append(cmd.ExtraFiles, cookie)
+	if timefile != nil {
+		cmd.Env = append(cmd.Env, "NTP_TIMEFILE=1")
+		cmd.ExtraFiles = append(cmd.ExtraFiles, timefile)
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Why? Reduce the wall time during which the system believes it's 1970.
Makes syslog timestamps more sensible.